### PR TITLE
Add pokers regression test suite 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib==3.9.0
 tensorboard==2.18.0
 argparse
 tqdm==4.67.0
-pokers-db==2.2
+pokers @ git+https://github.com/dberweger2017/pokers.git@f11337b694a281323564c0c6dd924d5d1163a28b
 python-dotenv==1.0.1
 requests==2.32.3
 seaborn==0.13.2

--- a/tests/test_pokers_regressions.py
+++ b/tests/test_pokers_regressions.py
@@ -1,0 +1,77 @@
+"""
+Regression tests for `pokers` behavior relied on by this project.
+
+Run with:
+`python3 -m pytest tests/test_pokers_regressions.py -q`
+
+Add future fixes as new entries in `REGRESSION_CASES`.
+"""
+
+import pokers as pkrs
+import pytest
+
+
+REGRESSION_CASES = [
+    pytest.param(
+        {
+            "setup": {
+                "n_players": 3,
+                "button": 0,
+                "sb": 1.0,
+                "bb": 2.0,
+                "stake": 4.0,
+                "seed": 0,
+            },
+            "actions": [
+                (pkrs.ActionEnum.Raise, 2.0),
+                (pkrs.ActionEnum.Call, 0.0),
+                (pkrs.ActionEnum.Call, 0.0),
+            ],
+            "expected": {
+                "stage": pkrs.Stage.Showdown,
+                "status": pkrs.StateStatus.Ok,
+                "final_state": True,
+                "legal_actions": [],
+                "zero_sum": True,
+            },
+            "milestones": {
+                1: {"final_state": False},
+                2: {"final_state": False},
+            },
+        },
+        id="all-in-runout-goes-straight-to-showdown",
+    ),
+]
+
+
+def replay_case(case):
+    """Return the full state trace for a regression case."""
+    state = pkrs.State.from_seed(**case["setup"])
+    trace = [state]
+
+    for action_enum, amount in case["actions"]:
+        state = state.apply_action(pkrs.Action(action_enum, amount=amount))
+        trace.append(state)
+
+    return trace
+
+
+@pytest.mark.parametrize("case", REGRESSION_CASES)
+def test_pokers_regressions(case):
+    trace = replay_case(case)
+
+    for action_index, checks in case.get("milestones", {}).items():
+        state = trace[action_index]
+        for attr_name, expected_value in checks.items():
+            assert getattr(state, attr_name) == expected_value
+
+    final_state = trace[-1]
+    expected = case["expected"]
+
+    assert final_state.stage == expected["stage"]
+    assert final_state.status == expected["status"]
+    assert final_state.final_state == expected["final_state"]
+    assert final_state.legal_actions == expected["legal_actions"]
+
+    if expected.get("zero_sum"):
+        assert abs(sum(player.reward for player in final_state.players_state)) < 1e-9


### PR DESCRIPTION
Summary

This PR fixes the all-in runout issue by depending on the patched pokers fork and adds a reusable regression suite in this repo so the behavior stays covered going forward.

The underlying bug was that after all remaining active players were effectively all-in, the game could continue on later streets with invalid legal_actions such as [Fold, Check, Raise]. In practice that allowed agents to:

choose Fold, ending the hand incorrectly before showdown
choose Raise, producing StateStatus.HighBet
choose Check, which only advanced to the next street and repeated the same broken state
Instead of adding local workarounds in the training and agent code, this PR points the project at the fixed pokers fork where the engine now runs forced checkdown situations directly through to showdown.

What Changed

Updated [requirements.txt](app://-/index.html?hostId=local#) to install pokers from the fixed fork commit:
dberweger2017/pokers
pinned to commit f11337b694a281323564c0c6dd924d5d1163a28b
Added [tests/test_pokers_regressions.py](app://-/index.html?hostId=local#)
this is a reusable regression suite for pokers behavior relied on by this repo
it uses a table-driven structure (REGRESSION_CASES) so future engine bugs can be added as new cases in one place
it includes the all-in runout regression that previously reproduced the bug
Regression Covered

The added regression test reproduces a concrete failing sequence:

n_players=3
button=0
sb=1.0
bb=2.0
stake=4.0
seed=0
Action sequence:

Raise(2.0)
Call
Call
Expected behavior after the fix:

the state goes directly to Stage.Showdown
final_state == True
status == StateStatus.Ok
legal_actions == []
the resulting rewards remain zero-sum
This protects the project from regressions where forced checkdown states incorrectly remain actionable.

Why This Approach

This repo has many call sites that trust state.legal_actions directly across:

training loops
agents
CLI play
GUI flows
evaluation code
A downstream workaround would have required duplicating guard logic across multiple paths and would still leave the root cause in the engine. Using the fixed pokers fork keeps the application code simpler and ensures every consumer of the game state sees the corrected behavior.

Validation

Validated locally with:

python3 -m pytest tests/test_pokers_regressions.py -q
Result:

1 passed

## Related
Closes #28