### PR TITLE
Pin pokers fix for all-in call states

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib==3.9.0
 tensorboard==2.18.0
 argparse
 tqdm==4.67.0
-pokers @ git+https://github.com/dberweger2017/pokers.git@f11337b694a281323564c0c6dd924d5d1163a28b
+pokers @ git+https://github.com/dberweger2017/pokers.git@b1a48bd2067176cb73f95286d2e8878e3a2eb3d1
 python-dotenv==1.0.1
 requests==2.32.3
 seaborn==0.13.2

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -47,11 +47,15 @@ def log_game_error(state: pkrs.State, action: pkrs.Action, error_msg: str,
     
     try:
         with open(log_filename, "w") as f:
+            stack_trace = traceback.format_exc()
+            if stack_trace.strip() == "NoneType: None":
+                stack_trace = "No active exception.\n"
+
             # Write error summary
             f.write(f"=== POKER GAME ERROR LOG ===\n")
             f.write(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
             f.write(f"Error: {error_msg}\n\n")
-            f.write(f"Stack trace:\n{traceback.format_exc()}\n\n")
+            f.write(f"Stack trace:\n{stack_trace}\n")
             
             # Write game state information
             f.write(f"=== GAME STATE ===\n")

--- a/tests/test_pokers_regressions.py
+++ b/tests/test_pokers_regressions.py
@@ -41,6 +41,29 @@ REGRESSION_CASES = [
         },
         id="all-in-runout-goes-straight-to-showdown",
     ),
+    pytest.param(
+        {
+            "setup": {
+                "n_players": 3,
+                "button": 0,
+                "sb": 1.0,
+                "bb": 2.0,
+                "stake": 4.0,
+                "seed": 0,
+            },
+            "actions": [
+                (pkrs.ActionEnum.Raise, 2.0),
+                (pkrs.ActionEnum.Call, 0.0),
+            ],
+            "expected": {
+                "stage": pkrs.Stage.Preflop,
+                "status": pkrs.StateStatus.Ok,
+                "final_state": False,
+                "legal_actions": [pkrs.ActionEnum.Fold, pkrs.ActionEnum.Call],
+            },
+        },
+        id="no-raise-when-call-uses-entire-stack",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

This PR updates the app repo to consume the `pokers` fix for issue `#26`, adds regression coverage here, and cleans up noisy error logging.

The underlying engine bug was that in some all-in-call spots the acting player could still be offered `Raise` even though calling used the full remaining stack. That allowed downstream code to create invalid raise actions and spam `StateStatus.HighBet` errors.

The actual game-logic fix lives in the forked `pokers` repository. This PR integrates that fix here.

## Changes

### 1. Pin `pokers` to the fixed commit

Updated [requirements.txt](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/requirements.txt) to point to:

- repo: `dberweger2017/pokers`
- commit: `b1a48bd2067176cb73f95286d2e8878e3a2eb3d1`

That commit removes `Raise` from `legal_actions` when calling consumes the entire stack.

### 2. Add regression coverage in this repo

Extended [tests/test_pokers_regressions.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/tests/test_pokers_regressions.py) with:

- `no-raise-when-call-uses-entire-stack`

This verifies that for the reproduced state:
- the hand is still in progress
- `status == StateStatus.Ok`
- `legal_actions == [Fold, Call]`

This keeps the dependency behavior checked from the app side as well.

### 3. Improve error log output

Updated [src/utils/logging.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/utils/logging.py) so that when no Python exception is active, the log no longer writes the misleading placeholder:

- `NoneType: None`

It now writes:
- `No active exception.`

That makes the repeated error logs easier to interpret.

## Why this approach

This repo has many code paths that trust `state.legal_actions` directly:
- agents
- evaluation loops
- training
- CLI / GUI flows

Fixing the engine is safer than scattering app-side workarounds, because every caller benefits from the corrected legal-action set automatically.

## Validation

Ran in this repo:

```bash
python3 -m pytest tests/test_pokers_regressions.py -q

## Solves
Closes #26 