### PR TITLE
Fix issue #22 training path regressions

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -3,10 +3,6 @@
 Standalone scripts for DeepCFR Poker AI.
 """
 
-from . import play
-from . import visualize_tournament
-from . import telegram_notifier
-
 __all__ = [
     'play',
     'visualize_tournament',

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,8 +5,6 @@ This package provides a deep learning implementation of Counterfactual Regret
 Minimization (CFR) for No-Limit Texas Hold'em Poker.
 """
 
-from . import core
-from . import opponent_modeling
-from . import training
-
 __version__ = "0.2.0"
+
+__all__ = ["core", "opponent_modeling", "training"]

--- a/src/core/deep_cfr.py
+++ b/src/core/deep_cfr.py
@@ -11,6 +11,13 @@ from src.core.model import PokerNetwork, encode_state, VERBOSE, set_verbose
 from src.utils.settings import STRICT_CHECKING
 from src.utils.logging import log_game_error
 
+
+def _resolve_model_save_path(path_prefix, iteration):
+    """Accept either a path prefix or an explicit .pt filename."""
+    if str(path_prefix).endswith(".pt"):
+        return str(path_prefix)
+    return f"{path_prefix}_iteration_{iteration}.pt"
+
 class PrioritizedMemory:
     """Enhanced memory buffer with prioritized experience replay."""
     def __init__(self, capacity, alpha=0.6):
@@ -864,17 +871,18 @@ class DeepCFRAgent:
 
     def save_model(self, path_prefix):
         """Save the model to disk."""
+        model_path = _resolve_model_save_path(path_prefix, self.iteration_count)
         torch.save({
             'iteration': self.iteration_count,
             'advantage_net': self.advantage_net.state_dict(),
             'strategy_net': self.strategy_net.state_dict(),
             'min_bet_size': self.min_bet_size,
             'max_bet_size': self.max_bet_size
-        }, f"{path_prefix}_iteration_{self.iteration_count}.pt")
+        }, model_path)
         
     def load_model(self, path):
         """Load the model from disk."""
-        checkpoint = torch.load(path)
+        checkpoint = torch.load(path, map_location=self.device)
         self.iteration_count = checkpoint['iteration']
         self.advantage_net.load_state_dict(checkpoint['advantage_net'])
         self.strategy_net.load_state_dict(checkpoint['strategy_net'])

--- a/src/opponent_modeling/deep_cfr_with_opponent_modeling.py
+++ b/src/opponent_modeling/deep_cfr_with_opponent_modeling.py
@@ -9,7 +9,12 @@ import pokers as pkrs
 from collections import deque
 from src.core.model import encode_state, VERBOSE, set_verbose
 from src.opponent_modeling.opponent_model import OpponentModelingSystem
-from src.core.deep_cfr import PrioritizedMemory
+from src.core.deep_cfr import (
+    DeepCFRAgent,
+    PrioritizedMemory,
+    _resolve_model_save_path,
+)
+from src.agents.random_agent import RandomAgent
 from src.utils.settings import STRICT_CHECKING
 from src.utils.logging import log_game_error
 
@@ -126,163 +131,8 @@ class DeepCFRAgentWithOpponentModeling:
         self.min_bet_size = 0.1
         self.max_bet_size = 3.0
     
-    def action_type_to_pokers_action(self, action_type, state, bet_size_multiplier=None):
-        """Convert action type and optional bet size to Pokers action."""
-        # NOTE: This function is identical to the one in DeepCFRAgent.
-        #       Consider refactoring into a shared utility if possible.
-        try:
-            if action_type == 0:  # Fold
-                # Ensure Fold is legal before returning
-                if pkrs.ActionEnum.Fold in state.legal_actions:
-                    return pkrs.Action(pkrs.ActionEnum.Fold)
-                else:
-                    # Fallback if Fold is somehow illegal (shouldn't happen often)
-                    if pkrs.ActionEnum.Check in state.legal_actions:
-                        return pkrs.Action(pkrs.ActionEnum.Check)
-                    elif pkrs.ActionEnum.Call in state.legal_actions:
-                        return pkrs.Action(pkrs.ActionEnum.Call)
-                    else:
-                        # If nothing else is legal, something is very wrong
-                        print("WARNING: No legal actions found, even Fold!")
-                        # Attempt Fold anyway as a last resort
-                        return pkrs.Action(pkrs.ActionEnum.Fold)
-
-            elif action_type == 1:  # Check/Call
-                if pkrs.ActionEnum.Check in state.legal_actions:
-                    return pkrs.Action(pkrs.ActionEnum.Check)
-                elif pkrs.ActionEnum.Call in state.legal_actions:
-                    return pkrs.Action(pkrs.ActionEnum.Call)
-                else:
-                    # Fallback if neither Check nor Call is legal
-                    if pkrs.ActionEnum.Fold in state.legal_actions:
-                        return pkrs.Action(pkrs.ActionEnum.Fold)
-                    else:
-                        print("WARNING: Check/Call chosen but neither is legal!")
-                        # Attempt Check as a last resort if available
-                        return pkrs.Action(pkrs.ActionEnum.Check)
-
-
-            elif action_type == 2:  # Raise
-                # First, check if Raise itself is a legal action type
-                if pkrs.ActionEnum.Raise not in state.legal_actions:
-                    # If Raise is not legal, fall back to Call or Check
-                    if pkrs.ActionEnum.Call in state.legal_actions:
-                        return pkrs.Action(pkrs.ActionEnum.Call)
-                    elif pkrs.ActionEnum.Check in state.legal_actions:
-                        return pkrs.Action(pkrs.ActionEnum.Check)
-                    else:
-                        # If neither Call nor Check is available, Fold
-                        return pkrs.Action(pkrs.ActionEnum.Fold)
-
-                # Get current player state
-                player_state = state.players_state[state.current_player]
-                current_bet = player_state.bet_chips
-                available_stake = player_state.stake
-
-                # Calculate what's needed to call (match the current min_bet)
-                call_amount = max(0, state.min_bet - current_bet)
-
-                # *** CORRECTED LOGIC HERE ***
-                # If player doesn't have enough chips *beyond* the call amount to make a valid raise,
-                # or if they are going all-in just to call, it should be a Call action.
-                # A raise requires putting in *more* than the call amount.
-                # The minimum additional raise amount is typically the big blind or 1 chip.
-                min_raise_increment = 1.0 # A small default
-                if hasattr(state, 'bb'):
-                    min_raise_increment = max(1.0, state.bb) # Usually BB, but at least 1
-
-                if available_stake <= call_amount + min_raise_increment:
-                    # Player cannot make a valid raise (or is all-in just to call).
-                    # This action should be treated as a Call.
-                    if VERBOSE:
-                        print(f"Action type 2 (Raise) chosen, but player cannot make a valid raise. "
-                              f"Stake: {available_stake}, Call Amount: {call_amount}. Switching to Call.")
-                    # Ensure Call is legal before returning it
-                    if pkrs.ActionEnum.Call in state.legal_actions:
-                        return pkrs.Action(pkrs.ActionEnum.Call)
-                    else:
-                        # If Call is not legal (edge case, e.g., already all-in matching bet), Fold.
-                         if VERBOSE:
-                             print(f"WARNING: Cannot Call (not legal), falling back to Fold.")
-                         return pkrs.Action(pkrs.ActionEnum.Fold)
-                # *** END OF CORRECTION ***
-
-                # If we reach here, the player *can* make a valid raise.
-                remaining_stake_after_call = available_stake - call_amount
-
-                # Calculate target raise amount based on pot multiplier
-                pot_size = max(1.0, state.pot) # Avoid division by zero
-                if bet_size_multiplier is None:
-                    # Default to 1x pot if no multiplier provided
-                    bet_size_multiplier = 1.0
-
-                # Ensure multiplier is within bounds
-                bet_size_multiplier = max(self.min_bet_size, min(self.max_bet_size, bet_size_multiplier))
-                target_additional_raise = pot_size * bet_size_multiplier
-
-                # Ensure minimum raise increment is met
-                target_additional_raise = max(target_additional_raise, min_raise_increment)
-
-                # Ensure we don't exceed available stake after calling
-                additional_amount = min(target_additional_raise, remaining_stake_after_call)
-
-                # Final check: Ensure the additional amount is at least the minimum required increment
-                if additional_amount < min_raise_increment:
-                     # This case should be rare due to the check above, but as a safeguard:
-                     if VERBOSE:
-                         print(f"Calculated raise amount {additional_amount} is less than min increment {min_raise_increment}. Falling back to Call.")
-                     if pkrs.ActionEnum.Call in state.legal_actions:
-                         return pkrs.Action(pkrs.ActionEnum.Call)
-                     else:
-                         return pkrs.Action(pkrs.ActionEnum.Fold)
-
-                if VERBOSE:
-                    print(f"\nRAISE CALCULATION DETAILS:")
-                    print(f"  Player ID: {state.current_player}")
-                    print(f"  Action type: {action_type}")
-                    print(f"  Current bet: {current_bet}")
-                    print(f"  Available stake: {available_stake}")
-                    print(f"  Min bet: {state.min_bet}")
-                    print(f"  Call amount: {call_amount}")
-                    print(f"  Pot size: {state.pot}")
-                    print(f"  Bet multiplier: {bet_size_multiplier}x pot")
-                    print(f"  Calculated additional raise amount: {additional_amount}")
-                    print(f"  Total player bet will be: {current_bet + call_amount + additional_amount}")
-
-                # Return the Raise action with the calculated *additional* amount
-                return pkrs.Action(pkrs.ActionEnum.Raise, additional_amount)
-
-            else:
-                raise ValueError(f"Unknown action type: {action_type}")
-
-        except Exception as e:
-            if VERBOSE:
-                print(f"ERROR creating action {action_type}: {e}")
-                print(f"State: current_player={state.current_player}, legal_actions={state.legal_actions}")
-                print(f"Player stake: {state.players_state[state.current_player].stake}")
-            # Fall back to call as safe option
-            if pkrs.ActionEnum.Call in state.legal_actions:
-                return pkrs.Action(pkrs.ActionEnum.Call)
-            elif pkrs.ActionEnum.Check in state.legal_actions:
-                return pkrs.Action(pkrs.ActionEnum.Check)
-            else:
-                return pkrs.Action(pkrs.ActionEnum.Fold)
-
-    def get_legal_action_types(self, state):
-        """Get the legal action types for the current state."""
-        legal_action_types = []
-        
-        # Check each action type
-        if pkrs.ActionEnum.Fold in state.legal_actions:
-            legal_action_types.append(0)
-            
-        if pkrs.ActionEnum.Check in state.legal_actions or pkrs.ActionEnum.Call in state.legal_actions:
-            legal_action_types.append(1)
-            
-        if pkrs.ActionEnum.Raise in state.legal_actions:
-            legal_action_types.append(2)
-        
-        return legal_action_types
+    action_type_to_pokers_action = DeepCFRAgent.action_type_to_pokers_action
+    get_legal_action_types = DeepCFRAgent.get_legal_action_types
     
     def extract_state_context(self, state):
         """
@@ -427,11 +277,8 @@ class DeepCFRAgentWithOpponentModeling:
             # Encode the base state
             state_tensor = torch.FloatTensor(encode_state(state, self.player_id)).to(self.device)
             
-            # Get opponent features for the current opponent
+            opponent_feature_array = np.zeros(20)
             opponent_features = None
-            if current_player != self.player_id:
-                opponent_features = self.opponent_modeling.get_opponent_features(current_player)
-                opponent_features = torch.FloatTensor(opponent_features).to(self.device)
             
             # Get advantages and bet sizing prediction from network
             with torch.no_grad():
@@ -517,7 +364,7 @@ class DeepCFRAgentWithOpponentModeling:
                 if action_type == 2:
                     self.advantage_memory.add(
                         (encode_state(state, self.player_id), 
-                         opponent_features.cpu().numpy() if opponent_features is not None else np.zeros(20),
+                         opponent_feature_array,
                          action_type, 
                          bet_size_multiplier, 
                          weighted_regret),
@@ -526,7 +373,7 @@ class DeepCFRAgentWithOpponentModeling:
                 else:
                     self.advantage_memory.add(
                         (encode_state(state, self.player_id),
-                         opponent_features.cpu().numpy() if opponent_features is not None else np.zeros(20),
+                         opponent_feature_array,
                          action_type, 
                          0.0, 
                          weighted_regret),
@@ -541,7 +388,7 @@ class DeepCFRAgentWithOpponentModeling:
             # Store strategy memory with opponent features if available
             self.strategy_memory.append((
                 encode_state(state, self.player_id),
-                opponent_features.cpu().numpy() if opponent_features is not None else np.zeros(20),
+                opponent_feature_array,
                 strategy_full,
                 bet_size_multiplier if 2 in legal_action_types else 0.0,
                 iteration
@@ -559,8 +406,6 @@ class DeepCFRAgentWithOpponentModeling:
                 if opponent is None:
                     if VERBOSE:
                         print(f"WARNING: No opponent at position {current_player}, using random action")
-                    # Create a temporary random agent for this position
-                    from src.training.train_with_opponent_modeling import RandomAgent
                     opponent = RandomAgent(current_player)
                 
                 # Let the opponent choose an action
@@ -782,17 +627,18 @@ class DeepCFRAgentWithOpponentModeling:
     
     def save_model(self, path_prefix):
         """Save the model to disk, including opponent modeling."""
+        model_path = _resolve_model_save_path(path_prefix, self.iteration_count)
         torch.save({
             'iteration': self.iteration_count,
             'advantage_net': self.advantage_net.state_dict(),
             'strategy_net': self.strategy_net.state_dict(),
             'history_encoder': self.opponent_modeling.history_encoder.state_dict(),
             'opponent_model': self.opponent_modeling.opponent_model.state_dict()
-        }, f"{path_prefix}_iteration_{self.iteration_count}.pt")
+        }, model_path)
         
     def load_model(self, path):
         """Load the model from disk, including opponent modeling if available."""
-        checkpoint = torch.load(path)
+        checkpoint = torch.load(path, map_location=self.device)
         self.iteration_count = checkpoint['iteration']
         self.advantage_net.load_state_dict(checkpoint['advantage_net'])
         self.strategy_net.load_state_dict(checkpoint['strategy_net'])

--- a/src/training/__init__.py
+++ b/src/training/__init__.py
@@ -2,10 +2,6 @@
 Training utilities and scripts for DeepCFR Poker AI.
 """
 
-from .train import train_deep_cfr
-from .train_with_opponent_modeling import train_deep_cfr_with_opponent_modeling
-from .train_mixed_with_opponent_modeling import train_mixed_with_opponent_modeling
-
 __all__ = [
     'train_deep_cfr',
     'train_deep_cfr_with_opponent_modeling',

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -5,7 +5,6 @@ import random
 import torch
 import time
 import os
-import matplotlib.pyplot as plt
 import argparse
 from src.core.deep_cfr import DeepCFRAgent
 from src.core.model import set_verbose, encode_state
@@ -72,6 +71,179 @@ def evaluate_against_random(agent, num_games=500, num_players=6):
         return 0
     
     return total_profit / completed_games
+
+
+class _PerspectiveAgentWrapper:
+    """Ensure each opponent acts using its own player_id."""
+
+    def __init__(self, agent):
+        self.agent = agent
+        self.player_id = agent.player_id
+
+    def choose_action(self, state):
+        return self.agent.choose_action(state)
+
+
+def _cfr_traverse_with_opponents(agent, state, iteration, opponent_agents, depth=0, verbose=False):
+    """Mirror DeepCFRAgent.cfr_traverse while sourcing opponent actions from fixed agents."""
+    max_depth = 1000
+    if depth > max_depth:
+        if verbose:
+            print(f"WARNING: Max recursion depth reached ({max_depth}). Returning zero value.")
+        return 0
+
+    if state.final_state:
+        return state.players_state[agent.player_id].reward
+
+    current_player = state.current_player
+
+    if current_player == agent.player_id:
+        legal_action_types = agent.get_legal_action_types(state)
+
+        if not legal_action_types:
+            if verbose:
+                print(f"WARNING: No legal actions found for player {current_player} at depth {depth}")
+            return 0
+
+        encoded_state = encode_state(state, agent.player_id)
+        state_tensor = torch.FloatTensor(encoded_state).to(agent.device)
+
+        with torch.no_grad():
+            advantages, bet_size_pred = agent.advantage_net(state_tensor.unsqueeze(0))
+            advantages = advantages[0].cpu().numpy()
+            bet_size_multiplier = bet_size_pred[0][0].item()
+
+        advantages_masked = np.zeros(agent.num_actions)
+        for action_type in legal_action_types:
+            advantages_masked[action_type] = max(advantages[action_type], 0)
+
+        if advantages_masked.sum() > 0:
+            strategy = advantages_masked / advantages_masked.sum()
+        else:
+            strategy = np.zeros(agent.num_actions)
+            for action_type in legal_action_types:
+                strategy[action_type] = 1.0 / len(legal_action_types)
+
+        action_values = np.zeros(agent.num_actions)
+        for action_type in legal_action_types:
+            try:
+                if action_type == 2:
+                    pokers_action = agent.action_type_to_pokers_action(
+                        action_type, state, bet_size_multiplier
+                    )
+                else:
+                    pokers_action = agent.action_type_to_pokers_action(action_type, state)
+
+                new_state = state.apply_action(pokers_action)
+
+                if new_state.status != pkrs.StateStatus.Ok:
+                    log_file = log_game_error(
+                        state, pokers_action, f"State status not OK ({new_state.status})"
+                    )
+                    if STRICT_CHECKING:
+                        raise ValueError(
+                            f"State status not OK ({new_state.status}) during CFR traversal. "
+                            f"Details logged to {log_file}"
+                        )
+                    if verbose:
+                        print(
+                            f"WARNING: Invalid action {action_type} at depth {depth}. "
+                            f"Status: {new_state.status}"
+                        )
+                        print(
+                            f"Player: {current_player}, Action: {pokers_action.action}, "
+                            f"Amount: {pokers_action.amount if pokers_action.action == pkrs.ActionEnum.Raise else 'N/A'}"
+                        )
+                        print(
+                            f"Current bet: {state.players_state[current_player].bet_chips}, "
+                            f"Stake: {state.players_state[current_player].stake}"
+                        )
+                        print(f"Details logged to {log_file}")
+                    continue
+
+                action_values[action_type] = _cfr_traverse_with_opponents(
+                    agent, new_state, iteration, opponent_agents, depth + 1, verbose
+                )
+            except Exception as exc:
+                if verbose:
+                    print(f"ERROR in traversal for action {action_type}: {exc}")
+                action_values[action_type] = 0
+                if STRICT_CHECKING:
+                    raise
+
+        ev = sum(strategy[action_type] * action_values[action_type] for action_type in legal_action_types)
+        max_abs_val = max(abs(max(action_values)), abs(min(action_values)), 1.0)
+        opponent_features = np.zeros(20)
+
+        for action_type in legal_action_types:
+            regret = action_values[action_type] - ev
+            normalized_regret = regret / max_abs_val
+            clipped_regret = np.clip(normalized_regret, -10.0, 10.0)
+            scale_factor = np.sqrt(iteration) if iteration > 1 else 1.0
+            weighted_regret = clipped_regret * scale_factor
+            priority = abs(weighted_regret) + 0.01
+
+            agent.advantage_memory.add(
+                (
+                    encoded_state,
+                    opponent_features,
+                    action_type,
+                    bet_size_multiplier if action_type == 2 else 0.0,
+                    weighted_regret,
+                ),
+                priority,
+            )
+
+        strategy_full = np.zeros(agent.num_actions)
+        for action_type in legal_action_types:
+            strategy_full[action_type] = strategy[action_type]
+
+        agent.strategy_memory.append(
+            (
+                encoded_state,
+                opponent_features,
+                strategy_full,
+                bet_size_multiplier if 2 in legal_action_types else 0.0,
+                iteration,
+            )
+        )
+
+        return ev
+
+    try:
+        opponent_agent = opponent_agents[current_player]
+        if opponent_agent is None:
+            if verbose:
+                print(f"WARNING: No opponent agent for position {current_player}")
+            return 0
+
+        action = opponent_agent.choose_action(state)
+        new_state = state.apply_action(action)
+
+        if new_state.status != pkrs.StateStatus.Ok:
+            log_file = log_game_error(state, action, f"State status not OK ({new_state.status})")
+            if STRICT_CHECKING:
+                raise ValueError(
+                    f"State status not OK ({new_state.status}) from opponent agent. "
+                    f"Details logged to {log_file}"
+                )
+            if verbose:
+                print(
+                    f"WARNING: Opponent agent made invalid action at depth {depth}. "
+                    f"Status: {new_state.status}"
+                )
+                print(f"Details logged to {log_file}")
+            return 0
+
+        return _cfr_traverse_with_opponents(
+            agent, new_state, iteration, opponent_agents, depth + 1, verbose
+        )
+    except Exception as exc:
+        if verbose:
+            print(f"ERROR in opponent agent traversal: {exc}")
+        if STRICT_CHECKING:
+            raise
+        return 0
 
 def train_deep_cfr(num_iterations=1000, traversals_per_iteration=200, 
                    num_players=6, player_id=0, save_dir="models", 
@@ -233,7 +405,10 @@ def continue_training(checkpoint_path, additional_iterations=1000,
     
     # Load the checkpoint
     print(f"Loading checkpoint from {checkpoint_path}")
-    checkpoint = torch.load(checkpoint_path)
+    checkpoint = torch.load(
+        checkpoint_path,
+        map_location='cuda' if torch.cuda.is_available() else 'cpu',
+    )
     
     # Initialize the agent
     num_players = 6  # Assuming 6 players as in the original training
@@ -426,274 +601,105 @@ def train_against_checkpoint(checkpoint_path, additional_iterations=1000,
     
     # Checkpoint frequency
     checkpoint_frequency = 100  # Save more frequently for self-play
-    
-    class AgentWrapper:
-        """Wrapper to ensure agents receive observations from their own perspective"""
-        def __init__(self, agent):
-            self.agent = agent
-            self.player_id = agent.player_id
-            
-        def choose_action(self, state):
-            # This is critical - the agent views the state from its own perspective
-            return self.agent.choose_action(state)
-    
-    # Save the original cfr_traverse method so we can restore it later
-    original_cfr_traverse = DeepCFRAgent.cfr_traverse
-    
-    # Define a modified cfr_traverse method for self-play
-    def self_play_cfr_traverse(self, state, iteration, opponent_agents, depth=0):
-        """
-        Modified CFR traverse method to ensure proper state perspective for each agent.
-        """
-        # Add recursion depth protection
-        max_depth = 1000
-        if depth > max_depth:
-            if verbose:
-                print(f"WARNING: Max recursion depth reached ({max_depth}). Returning zero value.")
-            return 0
-        
-        if state.final_state:
-            # Return payoff for the trained agent
-            return state.players_state[self.player_id].reward
-        
-        current_player = state.current_player
-        
-        # Debug information for the current state
-        if verbose and depth % 100 == 0:
-            print(f"Depth: {depth}, Player: {current_player}, Stage: {state.stage}")
-        
-        # If it's the trained agent's turn
-        if current_player == self.player_id:
-            legal_action_ids = self.get_legal_action_ids(state)
-            
-            if not legal_action_ids:
-                if verbose:
-                    print(f"WARNING: No legal actions found for player {current_player} at depth {depth}")
-                return 0
-                
-            # Encode state from this agent's perspective
-            state_tensor = torch.FloatTensor(encode_state(state, self.player_id)).to(self.device)
-            
-            # Get advantages from network
-            with torch.no_grad():
-                advantages = self.advantage_net(state_tensor.unsqueeze(0))[0]
-                
-            # Use regret matching to compute strategy
-            advantages_np = advantages.cpu().numpy()
-            advantages_masked = np.zeros(self.num_actions)
-            for a in legal_action_ids:
-                advantages_masked[a] = max(advantages_np[a], 0)
-                
-            # Choose an action based on the strategy
-            if sum(advantages_masked) > 0:
-                strategy = advantages_masked / sum(advantages_masked)
-            else:
-                strategy = np.zeros(self.num_actions)
-                for a in legal_action_ids:
-                    strategy[a] = 1.0 / len(legal_action_ids)
-            
-            # Choose actions and traverse
-            action_values = np.zeros(self.num_actions)
-            for action_id in legal_action_ids:
-                try:
-                    pokers_action = self.action_id_to_pokers_action(action_id, state)
-                    new_state = state.apply_action(pokers_action)
-                    
-                    # Check if the action was valid
-                    if new_state.status != pkrs.StateStatus.Ok:
-                        if verbose:
-                            print(f"WARNING: Invalid action {action_id} at depth {depth}. Status: {new_state.status}")
-                        continue
-                        
-                    action_values[action_id] = self.cfr_traverse(new_state, iteration, opponent_agents, depth + 1)
-                except Exception as e:
-                    if verbose:
-                        print(f"ERROR in traversal for action {action_id}: {e}")
-                    action_values[action_id] = 0
-            
-            # Compute counterfactual regrets and add to memory
-            ev = sum(strategy[a] * action_values[a] for a in legal_action_ids)
-            
-            # Calculate normalization factor
-            max_abs_val = max(abs(max(action_values)), abs(min(action_values)), 1.0)
-            
-            for action_id in legal_action_ids:
-                # Calculate regret
-                regret = action_values[action_id] - ev
-                
-                # Normalize and clip regret
-                normalized_regret = regret / max_abs_val
-                clipped_regret = np.clip(normalized_regret, -10.0, 10.0)
-                
-                # Apply scaling
-                scale_factor = np.sqrt(iteration) if iteration > 1 else 1.0
-                
-                self.advantage_memory.append((
-                    encode_state(state, self.player_id),  # Encode from this agent's perspective
-                    action_id,
-                    clipped_regret * scale_factor
-                ))
-            
-            # Add to strategy memory
-            strategy_full = np.zeros(self.num_actions)
-            for a in legal_action_ids:
-                strategy_full[a] = strategy[a]
-            
-            self.strategy_memory.append((
-                encode_state(state, self.player_id),  # Encode from this agent's perspective
-                strategy_full,
-                iteration
-            ))
-            
-            return ev
-            
-        # If it's another player's turn (opponent agent)
-        else:
-            try:
-                # Let the appropriate opponent agent choose an action
-                if opponent_agents[current_player] is not None:
-                    action = opponent_agents[current_player].choose_action(state)
-                    new_state = state.apply_action(action)
-                    
-                    # Check if the action was valid
-                    if new_state.status != pkrs.StateStatus.Ok:
-                        if verbose:
-                            print(f"WARNING: Opponent agent made invalid action at depth {depth}. Status: {new_state.status}")
-                        return 0
-                        
-                    return self.cfr_traverse(new_state, iteration, opponent_agents, depth + 1)
-                else:
-                    # This should not happen - all opponent positions should have agents
-                    if verbose:
-                        print(f"WARNING: No opponent agent for position {current_player}")
-                    return 0
-            except Exception as e:
-                if verbose:
-                    print(f"ERROR in opponent agent traversal: {e}")
-                return 0
-    
-    # Replace the cfr_traverse method with our self-play version
-    DeepCFRAgent.cfr_traverse = self_play_cfr_traverse
-    
-    try:
-        # Training loop
-        for iteration in range(1, additional_iterations + 1):
-            learning_agent.iteration_count = iteration
-            start_time = time.time()
-            
-            print(f"Self-play Iteration {iteration}/{additional_iterations}")
-            
-            # Run traversals to collect data
-            print("  Collecting data...")
-            for t in range(traversals_per_iteration):
-                # Rotate the button position for fairness
-                button_pos = t % 6
-                
-                # Create a new poker game
-                state = pkrs.State.from_seed(
-                    n_players=6,
-                    button=button_pos,
-                    sb=1,
-                    bb=2,
-                    stake=200.0,
-                    seed=random.randint(0, 10000)
-                )
-                
-                # Set up the opponent agents for this traversal
-                # The learning agent always plays as player 0
-                opponent_wrappers = [None] * 6
-                for pos in range(6):
-                    if pos != 0:  # Not the learning agent's position
-                        # Use the opponent agent for this position
-                        opponent_wrappers[pos] = AgentWrapper(opponent_agents[pos])
-                
-                # Perform CFR traversal
-                learning_agent.cfr_traverse(state, iteration, opponent_wrappers)
-            
-            # Track traversal time
-            traversal_time = time.time() - start_time
-            writer.add_scalar('Time/Traversal', traversal_time, iteration)
-            
-            # Train advantage network
-            print("  Training advantage network...")
-            adv_loss = learning_agent.train_advantage_network()
-            losses.append(adv_loss)
-            print(f"  Advantage network loss: {adv_loss:.6f}")
-            
-            # Log the loss to tensorboard
-            writer.add_scalar('Loss/Advantage', adv_loss, iteration)
-            writer.add_scalar('Memory/Advantage', len(learning_agent.advantage_memory), iteration)
-            
-            # Every few iterations, train the strategy network and evaluate
-            if iteration % 10 == 0 or iteration == additional_iterations:
-                print("  Training strategy network...")
-                strat_loss = learning_agent.train_strategy_network()
-                print(f"  Strategy network loss: {strat_loss:.6f}")
-                writer.add_scalar('Loss/Strategy', strat_loss, iteration)
-                
-                # Evaluate against checkpoint agents
-                print("  Evaluating against checkpoint agent...")
-                avg_profit_vs_checkpoint = evaluate_against_checkpoint_agents(
-                    learning_agent, opponent_agents, num_games=100)
-                print(f"  Average profit vs checkpoint: {avg_profit_vs_checkpoint:.2f}")
-                writer.add_scalar('Performance/ProfitVsCheckpoint', 
-                                avg_profit_vs_checkpoint, iteration)
-                
-                # Also evaluate against random for comparison
-                print("  Evaluating against random agents...")
-                avg_profit_random = evaluate_against_random(
-                    learning_agent, num_games=500, num_players=6)
-                profits.append(avg_profit_random)
-                print(f"  Average profit vs random: {avg_profit_random:.2f}")
-                writer.add_scalar('Performance/ProfitVsRandom', 
-                                avg_profit_random, iteration)
-                
-                # Save the model
-                #model_path = f"{save_dir}/deep_cfr_selfplay_iter_{iteration}"
-                #learning_agent.save_model(model_path)
-                #print(f"  Model saved to {model_path}")
-            
-            # Save checkpoint periodically
-            if iteration % checkpoint_frequency == 0:
-                checkpoint_path = f"{save_dir}/selfplay_checkpoint_iter_{iteration}.pt"
-                torch.save({
-                    'iteration': iteration,
-                    'advantage_net': learning_agent.advantage_net.state_dict(),
-                    'strategy_net': learning_agent.strategy_net.state_dict(),
-                    'losses': losses,
-                    'profits': profits
-                }, checkpoint_path)
-                print(f"  Checkpoint saved to {checkpoint_path}")
-            
-            elapsed = time.time() - start_time
-            writer.add_scalar('Time/Iteration', elapsed, iteration)
-            print(f"  Iteration completed in {elapsed:.2f} seconds")
-            print(f"  Advantage memory size: {len(learning_agent.advantage_memory)}")
-            print(f"  Strategy memory size: {len(learning_agent.strategy_memory)}")
-            writer.add_scalar('Memory/Strategy', len(learning_agent.strategy_memory), iteration)
-            
-            # Commit the tensorboard logs
-            writer.flush()
-            print()
-        
-        # Final evaluation with more games
-        print("Final evaluation...")
-        avg_profit_vs_checkpoint = evaluate_against_checkpoint_agents(
-            learning_agent, opponent_agents, num_games=500)
-        print(f"Final performance vs checkpoint: Average profit per game: {avg_profit_vs_checkpoint:.2f}")
-        writer.add_scalar('Performance/FinalProfitVsCheckpoint', avg_profit_vs_checkpoint, 0)
-        
-        avg_profit_random = evaluate_against_random(learning_agent, num_games=500)
-        print(f"Final performance vs random: Average profit per game: {avg_profit_random:.2f}")
-        writer.add_scalar('Performance/FinalProfitVsRandom', avg_profit_random, 0)
-        
-        writer.close()
-        
-        return learning_agent, losses, profits
-    
-    finally:
-        # Restore the original cfr_traverse method to avoid side effects
-        DeepCFRAgent.cfr_traverse = original_cfr_traverse
+    opponent_wrappers = [None] * 6
+    for pos in range(6):
+        if pos != learning_agent.player_id:
+            opponent_wrappers[pos] = _PerspectiveAgentWrapper(opponent_agents[pos])
+
+    # Training loop
+    for iteration in range(1, additional_iterations + 1):
+        learning_agent.iteration_count = iteration
+        start_time = time.time()
+
+        print(f"Self-play Iteration {iteration}/{additional_iterations}")
+
+        # Run traversals to collect data
+        print("  Collecting data...")
+        for t in range(traversals_per_iteration):
+            button_pos = t % 6
+
+            state = pkrs.State.from_seed(
+                n_players=6,
+                button=button_pos,
+                sb=1,
+                bb=2,
+                stake=200.0,
+                seed=random.randint(0, 10000)
+            )
+
+            _cfr_traverse_with_opponents(
+                learning_agent, state, iteration, opponent_wrappers, verbose=verbose
+            )
+
+        traversal_time = time.time() - start_time
+        writer.add_scalar('Time/Traversal', traversal_time, iteration)
+
+        print("  Training advantage network...")
+        adv_loss = learning_agent.train_advantage_network()
+        losses.append(adv_loss)
+        print(f"  Advantage network loss: {adv_loss:.6f}")
+
+        writer.add_scalar('Loss/Advantage', adv_loss, iteration)
+        writer.add_scalar('Memory/Advantage', len(learning_agent.advantage_memory), iteration)
+
+        if iteration % 10 == 0 or iteration == additional_iterations:
+            print("  Training strategy network...")
+            strat_loss = learning_agent.train_strategy_network()
+            print(f"  Strategy network loss: {strat_loss:.6f}")
+            writer.add_scalar('Loss/Strategy', strat_loss, iteration)
+
+            print("  Evaluating against checkpoint agent...")
+            avg_profit_vs_checkpoint = evaluate_against_checkpoint_agents(
+                learning_agent, opponent_agents, num_games=100
+            )
+            print(f"  Average profit vs checkpoint: {avg_profit_vs_checkpoint:.2f}")
+            writer.add_scalar(
+                'Performance/ProfitVsCheckpoint', avg_profit_vs_checkpoint, iteration
+            )
+
+            print("  Evaluating against random agents...")
+            avg_profit_random = evaluate_against_random(
+                learning_agent, num_games=500, num_players=6
+            )
+            profits.append(avg_profit_random)
+            print(f"  Average profit vs random: {avg_profit_random:.2f}")
+            writer.add_scalar('Performance/ProfitVsRandom', avg_profit_random, iteration)
+
+        if iteration % checkpoint_frequency == 0:
+            checkpoint_path = f"{save_dir}/selfplay_checkpoint_iter_{iteration}.pt"
+            torch.save({
+                'iteration': iteration,
+                'advantage_net': learning_agent.advantage_net.state_dict(),
+                'strategy_net': learning_agent.strategy_net.state_dict(),
+                'losses': losses,
+                'profits': profits
+            }, checkpoint_path)
+            print(f"  Checkpoint saved to {checkpoint_path}")
+
+        elapsed = time.time() - start_time
+        writer.add_scalar('Time/Iteration', elapsed, iteration)
+        print(f"  Iteration completed in {elapsed:.2f} seconds")
+        print(f"  Advantage memory size: {len(learning_agent.advantage_memory)}")
+        print(f"  Strategy memory size: {len(learning_agent.strategy_memory)}")
+        writer.add_scalar('Memory/Strategy', len(learning_agent.strategy_memory), iteration)
+
+        writer.flush()
+        print()
+
+    print("Final evaluation...")
+    avg_profit_vs_checkpoint = evaluate_against_checkpoint_agents(
+        learning_agent, opponent_agents, num_games=500
+    )
+    print(f"Final performance vs checkpoint: Average profit per game: {avg_profit_vs_checkpoint:.2f}")
+    writer.add_scalar('Performance/FinalProfitVsCheckpoint', avg_profit_vs_checkpoint, 0)
+
+    avg_profit_random = evaluate_against_random(learning_agent, num_games=500)
+    print(f"Final performance vs random: Average profit per game: {avg_profit_random:.2f}")
+    writer.add_scalar('Performance/FinalProfitVsRandom', avg_profit_random, 0)
+
+    writer.close()
+
+    return learning_agent, losses, profits
 
 def evaluate_against_checkpoint_agents(agent, opponent_agents, num_games=100):
     """
@@ -838,375 +844,175 @@ def train_with_mixed_checkpoints(checkpoint_dir, training_model_prefix="t_",
     
     # Checkpoint frequency for saving our learning agent
     checkpoint_frequency = 100
-    
-    # Helper class for agent wrappers
-    class AgentWrapper:
-        """Wrapper to ensure agents receive observations from their own perspective"""
-        def __init__(self, agent):
-            self.agent = agent
-            self.player_id = agent.player_id
-            
-        def choose_action(self, state):
-            # This is critical - the agent views the state from its own perspective
-            return self.agent.choose_action(state)
-    
-    # Save the original cfr_traverse method so we can restore it later
-    original_cfr_traverse = DeepCFRAgent.cfr_traverse
-    
-    # Define a modified cfr_traverse method for mixed checkpoint training
-    def mixed_checkpoints_cfr_traverse(self, state, iteration, opponent_agents, depth=0):
-        """
-        Modified CFR traverse method to ensure proper state perspective for each agent.
-        """
-        # Add recursion depth protection
-        max_depth = 1000
-        if depth > max_depth:
-            if verbose:
-                print(f"WARNING: Max recursion depth reached ({max_depth}). Returning zero value.")
-            return 0
-        
-        if state.final_state:
-            # Return payoff for the trained agent
-            return state.players_state[self.player_id].reward
-        
-        current_player = state.current_player
-        
-        # Debug information for the current state
-        if verbose and depth % 100 == 0:
-            print(f"Depth: {depth}, Player: {current_player}, Stage: {state.stage}")
-        
-        # If it's the trained agent's turn
-        if current_player == self.player_id:
-            legal_action_ids = self.get_legal_action_ids(state)
-            
-            if not legal_action_ids:
-                if verbose:
-                    print(f"WARNING: No legal actions found for player {current_player} at depth {depth}")
-                return 0
-                
-            # Encode state from this agent's perspective
-            state_tensor = torch.FloatTensor(encode_state(state, self.player_id)).to(self.device)
-            
-            # Get advantages from network
-            with torch.no_grad():
-                advantages = self.advantage_net(state_tensor.unsqueeze(0))[0]
-                
-            # Use regret matching to compute strategy
-            advantages_np = advantages.cpu().numpy()
-            advantages_masked = np.zeros(self.num_actions)
-            for a in legal_action_ids:
-                advantages_masked[a] = max(advantages_np[a], 0)
-                
-            # Choose an action based on the strategy
-            if sum(advantages_masked) > 0:
-                strategy = advantages_masked / sum(advantages_masked)
-            else:
-                strategy = np.zeros(self.num_actions)
-                for a in legal_action_ids:
-                    strategy[a] = 1.0 / len(legal_action_ids)
-            
-            # Choose actions and traverse
-            action_values = np.zeros(self.num_actions)
-            for action_id in legal_action_ids:
-                try:
-                    pokers_action = self.action_id_to_pokers_action(action_id, state)
-                    new_state = state.apply_action(pokers_action)
-                    
-                    # Check if the action was valid
-                    if new_state.status != pkrs.StateStatus.Ok:
-                        if verbose:
-                            print(f"WARNING: Invalid action {action_id} at depth {depth}. Status: {new_state.status}")
-                        continue
-                        
-                    action_values[action_id] = self.cfr_traverse(new_state, iteration, opponent_agents, depth + 1)
-                except Exception as e:
-                    if verbose:
-                        print(f"ERROR in traversal for action {action_id}: {e}")
-                    action_values[action_id] = 0
-            
-            # Compute counterfactual regrets and add to memory
-            ev = sum(strategy[a] * action_values[a] for a in legal_action_ids)
-            
-            # Calculate normalization factor
-            max_abs_val = max(abs(max(action_values)), abs(min(action_values)), 1.0)
-            
-            for action_id in legal_action_ids:
-                # Calculate regret
-                regret = action_values[action_id] - ev
-                
-                # Normalize and clip regret
-                normalized_regret = regret / max_abs_val
-                clipped_regret = np.clip(normalized_regret, -10.0, 10.0)
-                
-                # Apply scaling
-                scale_factor = np.sqrt(iteration) if iteration > 1 else 1.0
-                
-                self.advantage_memory.append((
-                    encode_state(state, self.player_id),  # Encode from this agent's perspective
-                    action_id,
-                    clipped_regret * scale_factor
-                ))
-            
-            # Add to strategy memory
-            strategy_full = np.zeros(self.num_actions)
-            for a in legal_action_ids:
-                strategy_full[a] = strategy[a]
-            
-            self.strategy_memory.append((
-                encode_state(state, self.player_id),  # Encode from this agent's perspective
-                strategy_full,
-                iteration
-            ))
-            
-            return ev
-            
-        # If it's another player's turn (checkpoint agent or random agent)
-        else:
-            try:
-                # Let the appropriate opponent agent choose an action
-                if opponent_agents[current_player] is not None:
-                    action = opponent_agents[current_player].choose_action(state)
-                    new_state = state.apply_action(action)
-                    
-                    # Check if the action was valid
-                    if new_state.status != pkrs.StateStatus.Ok:
-                        if verbose:
-                            print(f"WARNING: Opponent agent made invalid action at depth {depth}. Status: {new_state.status}")
-                        return 0
-                        
-                    return self.cfr_traverse(new_state, iteration, opponent_agents, depth + 1)
-                else:
-                    # This should not happen - all opponent positions should have agents
-                    if verbose:
-                        print(f"WARNING: No opponent agent for position {current_player}")
-                    return 0
-            except Exception as e:
-                if verbose:
-                    print(f"ERROR in opponent agent traversal: {e}")
-                return 0
-    
-    # Replace the cfr_traverse method with our mixed checkpoints version
-    DeepCFRAgent.cfr_traverse = mixed_checkpoints_cfr_traverse
-    
-    try:
-        # Function to select random checkpoints from the pool
-        def select_random_checkpoints():
-            # Get all checkpoint files with the specified prefix
-            checkpoint_files = glob.glob(os.path.join(checkpoint_dir, f"{training_model_prefix}*.pt"))
-            
-            if not checkpoint_files:
-                print(f"WARNING: No checkpoint files found with prefix '{training_model_prefix}' in {checkpoint_dir}")
-                # Create random agents as fallback
-                return [RandomAgent(i) for i in range(6)]
-            
-            # Select random checkpoints
-            selected_files = random.sample(checkpoint_files, min(num_opponents, len(checkpoint_files)))
-            print(f"Selected checkpoints: {[os.path.basename(f) for f in selected_files]}")
-            
-            # Create agents from the selected checkpoints
-            selected_agents = []
-            
-            # Always keep a random agent at position 1 (optional, can be modified)
-            random_agent = RandomAgent(1)
-            
-            # Load checkpoint agents for other positions
-            current_pos = 1
-            for checkpoint_file in selected_files:
-                # Skip position 0 as it's reserved for our learning agent
-                if current_pos == 0:
-                    current_pos += 1
-                
-                # Create and load agent
-                checkpoint_agent = DeepCFRAgent(player_id=current_pos, num_players=6, device=device)
-                checkpoint_agent.load_model(checkpoint_file)
-                
-                # Add to list
-                selected_agents.append((current_pos, checkpoint_agent))
-                current_pos += 1
-                if current_pos >= 6:
-                    current_pos = 1  # Wrap around, skipping position 0
-            
-            # Create the full opponent list
-            opponent_agents = [None] * 6  # Initialize with None
-            
-            # Set position 0 to None (will be our learning agent)
-            opponent_agents[0] = None
-            
-            # Set the random agent at position 1
-            opponent_agents[1] = random_agent
-            
-            # Fill in the checkpoint agents
-            for pos, agent in selected_agents:
-                if pos != 1:  # Skip position 1 as it's already the random agent
-                    opponent_agents[pos] = agent
-            
-            # Fill any remaining positions with random agents
-            for i in range(6):
-                if opponent_agents[i] is None and i != 0:
-                    opponent_agents[i] = RandomAgent(i)
-            
-            return opponent_agents
-        
-        # Select initial opponent agents
-        opponent_agents = select_random_checkpoints()
-        
-        # ADDED: Initial evaluation before training begins
-        print("Initial evaluation...")
-        initial_profit_vs_mixed = evaluate_against_checkpoint_agents(
-            learning_agent, opponent_agents, num_games=100)
-        profits_vs_checkpoints.append(initial_profit_vs_mixed)
-        print(f"Initial average profit vs mixed opponents: {initial_profit_vs_mixed:.2f}")
-        writer.add_scalar('Performance/ProfitVsMixed', initial_profit_vs_mixed, 0)
-        
-        # Also evaluate against random for baseline comparison
-        initial_profit_random = evaluate_against_random(
-            learning_agent, num_games=500, num_players=6)
-        profits.append(initial_profit_random)
-        print(f"Initial average profit vs random: {initial_profit_random:.2f}")
-        writer.add_scalar('Performance/ProfitVsRandom', initial_profit_random, 0)
-        
-        # Wrap agents to ensure proper perspective
+
+    def select_random_checkpoints():
+        checkpoint_files = glob.glob(os.path.join(checkpoint_dir, f"{training_model_prefix}*.pt"))
+
+        if not checkpoint_files:
+            print(
+                f"WARNING: No checkpoint files found with prefix '{training_model_prefix}' "
+                f"in {checkpoint_dir}"
+            )
+            return [RandomAgent(i) if i != 0 else None for i in range(6)]
+
+        selected_files = random.sample(checkpoint_files, min(num_opponents, len(checkpoint_files)))
+        print(f"Selected checkpoints: {[os.path.basename(f) for f in selected_files]}")
+
+        selected_agents = []
+        current_pos = 1
+        for checkpoint_file in selected_files:
+            checkpoint_agent = DeepCFRAgent(player_id=current_pos, num_players=6, device=device)
+            checkpoint_agent.load_model(checkpoint_file)
+            selected_agents.append((current_pos, checkpoint_agent))
+            current_pos += 1
+            if current_pos >= 6:
+                current_pos = 1
+
+        opponent_agents = [None] * 6
+        opponent_agents[1] = RandomAgent(1)
+
+        for pos, checkpoint_agent in selected_agents:
+            if pos != 1:
+                opponent_agents[pos] = checkpoint_agent
+
+        for pos in range(1, 6):
+            if opponent_agents[pos] is None:
+                opponent_agents[pos] = RandomAgent(pos)
+
+        return opponent_agents
+
+    def wrap_opponents(opponent_agents):
         opponent_wrappers = [None] * 6
         for pos in range(6):
-            if pos != 0 and opponent_agents[pos] is not None:
-                opponent_wrappers[pos] = AgentWrapper(opponent_agents[pos])
-        
-        # Training loop
-        for iteration in range(1, additional_iterations + 1):
-            learning_agent.iteration_count = iteration
-            start_time = time.time()
-            
-            # Refresh opponents at specified intervals
-            if iteration % refresh_interval == 1:
-                print(f"Refreshing opponent pool at iteration {iteration}")
-                opponent_agents = select_random_checkpoints()
-                
-                # Re-wrap agents
-                opponent_wrappers = [None] * 6
-                for pos in range(6):
-                    if pos != 0 and opponent_agents[pos] is not None:
-                        opponent_wrappers[pos] = AgentWrapper(opponent_agents[pos])
-            
-            print(f"Mixed-checkpoint training iteration {iteration}/{additional_iterations}")
-            
-            # Run traversals to collect data
-            print("  Collecting data...")
-            for t in range(traversals_per_iteration):
-                # Rotate the button position for fairness
-                button_pos = t % 6
-                
-                # Create a new poker game
-                state = pkrs.State.from_seed(
-                    n_players=6,
-                    button=button_pos,
-                    sb=1,
-                    bb=2,
-                    stake=200.0,
-                    seed=random.randint(0, 10000)
-                )
-                
-                # Perform CFR traversal
-                learning_agent.cfr_traverse(state, iteration, opponent_wrappers)
-            
-            # Track traversal time
-            traversal_time = time.time() - start_time
-            writer.add_scalar('Time/Traversal', traversal_time, iteration)
-            
-            # Train advantage network
-            print("  Training advantage network...")
-            adv_loss = learning_agent.train_advantage_network()
-            losses.append(adv_loss)
-            print(f"  Advantage network loss: {adv_loss:.6f}")
-            
-            # Log the loss to tensorboard
-            writer.add_scalar('Loss/Advantage', adv_loss, iteration)
-            writer.add_scalar('Memory/Advantage', len(learning_agent.advantage_memory), iteration)
-            
-            # Every few iterations, train the strategy network and evaluate
-            if iteration % 10 == 0 or iteration == additional_iterations:
-                print("  Training strategy network...")
-                strat_loss = learning_agent.train_strategy_network()
-                print(f"  Strategy network loss: {strat_loss:.6f}")
-                writer.add_scalar('Loss/Strategy', strat_loss, iteration)
-                
-                # Evaluate against current opponents
-                print("  Evaluating against current mixed opponents...")
-                avg_profit_vs_mixed = evaluate_against_checkpoint_agents(
-                    learning_agent, opponent_agents, num_games=100)
-                profits_vs_checkpoints.append(avg_profit_vs_mixed)
-                print(f"  Average profit vs mixed opponents: {avg_profit_vs_mixed:.2f}")
-                writer.add_scalar('Performance/ProfitVsMixed', 
-                                avg_profit_vs_mixed, iteration)
-                
-                # Also evaluate against random for baseline comparison
-                print("  Evaluating against random agents...")
-                avg_profit_random = evaluate_against_random(
-                    learning_agent, num_games=500, num_players=6)
-                profits.append(avg_profit_random)
-                print(f"  Average profit vs random: {avg_profit_random:.2f}")
-                writer.add_scalar('Performance/ProfitVsRandom', 
-                                avg_profit_random, iteration)
-                
-                # Save the model
-                #model_path = f"{save_dir}/deep_cfr_mixed_iter_{iteration}"
-                #learning_agent.save_model(model_path)
-                #print(f"  Model saved to {model_path}")
-                
-                # Also save as a training model that can be selected
-                if iteration % 100 == 0:
-                    t_model_path = f"{checkpoint_dir}/{training_model_prefix}mixed_iter_{iteration}.pt"
-                    torch.save({
-                        'iteration': iteration,
-                        'advantage_net': learning_agent.advantage_net.state_dict(),
-                        'strategy_net': learning_agent.strategy_net.state_dict()
-                    }, t_model_path)
-                    print(f"  Training model saved to {t_model_path}")
-            
-            # Save checkpoint periodically
-            if iteration % checkpoint_frequency == 0:
-                checkpoint_path = f"{save_dir}/mixed_checkpoint_iter_{iteration}.pt"
+            if pos != learning_agent.player_id and opponent_agents[pos] is not None:
+                opponent_wrappers[pos] = _PerspectiveAgentWrapper(opponent_agents[pos])
+        return opponent_wrappers
+
+    opponent_agents = select_random_checkpoints()
+
+    print("Initial evaluation...")
+    initial_profit_vs_mixed = evaluate_against_checkpoint_agents(
+        learning_agent, opponent_agents, num_games=100
+    )
+    profits_vs_checkpoints.append(initial_profit_vs_mixed)
+    print(f"Initial average profit vs mixed opponents: {initial_profit_vs_mixed:.2f}")
+    writer.add_scalar('Performance/ProfitVsMixed', initial_profit_vs_mixed, 0)
+
+    initial_profit_random = evaluate_against_random(
+        learning_agent, num_games=500, num_players=6
+    )
+    profits.append(initial_profit_random)
+    print(f"Initial average profit vs random: {initial_profit_random:.2f}")
+    writer.add_scalar('Performance/ProfitVsRandom', initial_profit_random, 0)
+
+    opponent_wrappers = wrap_opponents(opponent_agents)
+
+    for iteration in range(1, additional_iterations + 1):
+        learning_agent.iteration_count = iteration
+        start_time = time.time()
+
+        if iteration % refresh_interval == 1:
+            print(f"Refreshing opponent pool at iteration {iteration}")
+            opponent_agents = select_random_checkpoints()
+            opponent_wrappers = wrap_opponents(opponent_agents)
+
+        print(f"Mixed-checkpoint training iteration {iteration}/{additional_iterations}")
+
+        print("  Collecting data...")
+        for t in range(traversals_per_iteration):
+            button_pos = t % 6
+            state = pkrs.State.from_seed(
+                n_players=6,
+                button=button_pos,
+                sb=1,
+                bb=2,
+                stake=200.0,
+                seed=random.randint(0, 10000)
+            )
+
+            _cfr_traverse_with_opponents(
+                learning_agent, state, iteration, opponent_wrappers, verbose=verbose
+            )
+
+        traversal_time = time.time() - start_time
+        writer.add_scalar('Time/Traversal', traversal_time, iteration)
+
+        print("  Training advantage network...")
+        adv_loss = learning_agent.train_advantage_network()
+        losses.append(adv_loss)
+        print(f"  Advantage network loss: {adv_loss:.6f}")
+
+        writer.add_scalar('Loss/Advantage', adv_loss, iteration)
+        writer.add_scalar('Memory/Advantage', len(learning_agent.advantage_memory), iteration)
+
+        if iteration % 10 == 0 or iteration == additional_iterations:
+            print("  Training strategy network...")
+            strat_loss = learning_agent.train_strategy_network()
+            print(f"  Strategy network loss: {strat_loss:.6f}")
+            writer.add_scalar('Loss/Strategy', strat_loss, iteration)
+
+            print("  Evaluating against current mixed opponents...")
+            avg_profit_vs_mixed = evaluate_against_checkpoint_agents(
+                learning_agent, opponent_agents, num_games=100
+            )
+            profits_vs_checkpoints.append(avg_profit_vs_mixed)
+            print(f"  Average profit vs mixed opponents: {avg_profit_vs_mixed:.2f}")
+            writer.add_scalar('Performance/ProfitVsMixed', avg_profit_vs_mixed, iteration)
+
+            print("  Evaluating against random agents...")
+            avg_profit_random = evaluate_against_random(
+                learning_agent, num_games=500, num_players=6
+            )
+            profits.append(avg_profit_random)
+            print(f"  Average profit vs random: {avg_profit_random:.2f}")
+            writer.add_scalar('Performance/ProfitVsRandom', avg_profit_random, iteration)
+
+            if iteration % 100 == 0:
+                t_model_path = f"{checkpoint_dir}/{training_model_prefix}mixed_iter_{iteration}.pt"
                 torch.save({
                     'iteration': iteration,
                     'advantage_net': learning_agent.advantage_net.state_dict(),
-                    'strategy_net': learning_agent.strategy_net.state_dict(),
-                    'losses': losses,
-                    'profits': profits,
-                    'profits_vs_checkpoints': profits_vs_checkpoints
-                }, checkpoint_path)
-                print(f"  Checkpoint saved to {checkpoint_path}")
-            
-            elapsed = time.time() - start_time
-            writer.add_scalar('Time/Iteration', elapsed, iteration)
-            print(f"  Iteration completed in {elapsed:.2f} seconds")
-            print(f"  Advantage memory size: {len(learning_agent.advantage_memory)}")
-            print(f"  Strategy memory size: {len(learning_agent.strategy_memory)}")
-            writer.add_scalar('Memory/Strategy', len(learning_agent.strategy_memory), iteration)
-            
-            # Commit the tensorboard logs
-            writer.flush()
-            print()
-        
-        # Final evaluation with more games
-        print("Final evaluation...")
-        
-        # Evaluate against random opponents
-        avg_profit_random = evaluate_against_random(learning_agent, num_games=500)
-        print(f"Final performance vs random: Average profit per game: {avg_profit_random:.2f}")
-        writer.add_scalar('Performance/FinalProfitVsRandom', avg_profit_random, 0)
-        
-        # Evaluate against mixed opponents
-        avg_profit_vs_mixed = evaluate_against_checkpoint_agents(
-            learning_agent, opponent_agents, num_games=500)
-        print(f"Final performance vs mixed opponents: Average profit per game: {avg_profit_vs_mixed:.2f}")
-        writer.add_scalar('Performance/FinalProfitVsMixed', avg_profit_vs_mixed, 0)
-        
-        writer.close()
-        
-        return learning_agent, losses, profits, profits_vs_checkpoints
-    
-    finally:
-        # Restore the original cfr_traverse method to avoid side effects
-        DeepCFRAgent.cfr_traverse = original_cfr_traverse
+                    'strategy_net': learning_agent.strategy_net.state_dict()
+                }, t_model_path)
+                print(f"  Training model saved to {t_model_path}")
+
+        if iteration % checkpoint_frequency == 0:
+            checkpoint_path = f"{save_dir}/mixed_checkpoint_iter_{iteration}.pt"
+            torch.save({
+                'iteration': iteration,
+                'advantage_net': learning_agent.advantage_net.state_dict(),
+                'strategy_net': learning_agent.strategy_net.state_dict(),
+                'losses': losses,
+                'profits': profits,
+                'profits_vs_checkpoints': profits_vs_checkpoints
+            }, checkpoint_path)
+            print(f"  Checkpoint saved to {checkpoint_path}")
+
+        elapsed = time.time() - start_time
+        writer.add_scalar('Time/Iteration', elapsed, iteration)
+        print(f"  Iteration completed in {elapsed:.2f} seconds")
+        print(f"  Advantage memory size: {len(learning_agent.advantage_memory)}")
+        print(f"  Strategy memory size: {len(learning_agent.strategy_memory)}")
+        writer.add_scalar('Memory/Strategy', len(learning_agent.strategy_memory), iteration)
+
+        writer.flush()
+        print()
+
+    print("Final evaluation...")
+
+    avg_profit_random = evaluate_against_random(learning_agent, num_games=500)
+    print(f"Final performance vs random: Average profit per game: {avg_profit_random:.2f}")
+    writer.add_scalar('Performance/FinalProfitVsRandom', avg_profit_random, 0)
+
+    avg_profit_vs_mixed = evaluate_against_checkpoint_agents(
+        learning_agent, opponent_agents, num_games=500
+    )
+    print(f"Final performance vs mixed opponents: Average profit per game: {avg_profit_vs_mixed:.2f}")
+    writer.add_scalar('Performance/FinalProfitVsMixed', avg_profit_vs_mixed, 0)
+
+    writer.close()
+
+    return learning_agent, losses, profits, profits_vs_checkpoints
 
 if __name__ == "__main__":
     import argparse

--- a/src/training/train_mixed_with_opponent_modeling.py
+++ b/src/training/train_mixed_with_opponent_modeling.py
@@ -7,9 +7,8 @@ import random
 import time
 import argparse
 import glob
-from torch.utils.tensorboard import SummaryWriter
 from src.opponent_modeling.deep_cfr_with_opponent_modeling import DeepCFRAgentWithOpponentModeling
-from src.core.model import encode_state, set_verbose
+from src.core.model import set_verbose
 from src.agents.random_agent import RandomAgent
 
 class ModelAgent:
@@ -109,7 +108,7 @@ def evaluate_against_opponents(agent, opponents, num_games=100, iteration=0, not
                     
                     # Choose action
                     if current_player == agent.player_id:
-                        action = agent.choose_action(state, opponent_id=current_player)
+                        action = agent.choose_action(state, opponent_id=None)
                         is_training_agent = True
                     else:
                         action = opponents[current_player].choose_action(state)
@@ -293,11 +292,7 @@ def train_mixed_with_opponent_modeling(
     """
     # Import required modules
     from torch.utils.tensorboard import SummaryWriter
-    import glob
-    import os
-    import time
     from scripts.telegram_notifier import TelegramNotifier
-    import traceback
     
     # Set verbosity
     set_verbose(verbose)
@@ -307,7 +302,11 @@ def train_mixed_with_opponent_modeling(
     os.makedirs(log_dir, exist_ok=True)
     
     # Initialize Telegram notifier (reads from .env file)
-    notifier = TelegramNotifier()
+    try:
+        notifier = TelegramNotifier()
+    except Exception as exc:
+        print(f"Warning: Could not initialize Telegram notifier: {exc}")
+        notifier = None
     
     # Initialize tensorboard writer
     writer = SummaryWriter(log_dir)
@@ -315,7 +314,10 @@ def train_mixed_with_opponent_modeling(
     # Device setup
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     print(f"Using device: {device}")
-    notifier.send_message(f"🚀 <b>TRAINING STARTED</b>\nDevice: {device}\nIterations: {num_iterations}\nRefresh interval: {refresh_interval}")
+    if notifier:
+        notifier.send_message(
+            f"🚀 <b>TRAINING STARTED</b>\nDevice: {device}\nIterations: {num_iterations}\nRefresh interval: {refresh_interval}"
+        )
     
     # Initialize the agent with opponent modeling
     agent = DeepCFRAgentWithOpponentModeling(
@@ -337,13 +339,19 @@ def train_mixed_with_opponent_modeling(
                 starting_iteration = int(iteration_str) + 1
                 agent.iteration_count = starting_iteration - 1
                 print(f"Continuing from iteration {starting_iteration}")
-                notifier.send_message(f"📥 <b>LOADED CHECKPOINT</b>\nContinuing from iteration {starting_iteration}")
+                if notifier:
+                    notifier.send_message(
+                        f"📥 <b>LOADED CHECKPOINT</b>\nContinuing from iteration {starting_iteration}"
+                    )
             except Exception as e:
                 print(f"Could not determine iteration from checkpoint filename: {e}")
                 print("Starting from iteration 1")
         except Exception as e:
             print(f"Error loading checkpoint: {e}")
-            notifier.send_message(f"⚠️ <b>CHECKPOINT LOADING ERROR</b>\n{str(e)}\nStarting from scratch.")
+            if notifier:
+                notifier.send_message(
+                    f"⚠️ <b>CHECKPOINT LOADING ERROR</b>\n{str(e)}\nStarting from scratch."
+                )
     
     # For tracking progress
     advantage_losses = []
@@ -363,7 +371,7 @@ def train_mixed_with_opponent_modeling(
         if not checkpoint_files:
             print(f"WARNING: No checkpoint files found matching pattern '{model_prefix}' in {checkpoint_dir}")
             print("Using random agents as opponents")
-            return [RandomAgent(i) for i in range(6) if i != player_id]
+            return [None if i == player_id else RandomAgent(i) for i in range(6)]
         
         # Select random models
         selected_files = random.sample(checkpoint_files, min(num_opponents, len(checkpoint_files)))
@@ -375,7 +383,8 @@ def train_mixed_with_opponent_modeling(
             print(f"  {i+1}. {filename}")
         
         # Log selected opponents to Telegram
-        notifier.send_message(f"📊 <b>SELECTED OPPONENTS</b>\n- " + "\n- ".join(opponent_names))
+        if notifier:
+            notifier.send_message(f"📊 <b>SELECTED OPPONENTS</b>\n- " + "\n- ".join(opponent_names))
         
         # Load the selected models
         model_opponents = []
@@ -422,7 +431,8 @@ def train_mixed_with_opponent_modeling(
         # Refresh opponents at specified intervals
         if iteration % refresh_interval == 1 and iteration > starting_iteration:
             print(f"\n=== Refreshing opponent pool at iteration {iteration} ===")
-            notifier.send_message(f"🔄 <b>REFRESHING OPPONENTS</b> at iteration {iteration}")
+            if notifier:
+                notifier.send_message(f"🔄 <b>REFRESHING OPPONENTS</b> at iteration {iteration}")
             opponents = select_random_models()
         
         print(f"Iteration {iteration}/{num_iterations}")
@@ -446,7 +456,7 @@ def train_mixed_with_opponent_modeling(
             except Exception as e:
                 error_msg = f"Error during traversal: {e}"
                 print(error_msg)
-                if iteration % 100 == 0:  # Don't flood with error messages
+                if notifier and iteration % 100 == 0:  # Don't flood with error messages
                     notifier.send_message(f"⚠️ <b>TRAVERSAL ERROR</b>\n{error_msg}")
                 continue
         
@@ -480,7 +490,8 @@ def train_mixed_with_opponent_modeling(
             except Exception as e:
                 error_msg = f"Error training opponent modeling: {e}"
                 print(error_msg)
-                notifier.send_message(f"⚠️ <b>OPPONENT MODELING ERROR</b>\n{error_msg}")
+                if notifier:
+                    notifier.send_message(f"⚠️ <b>OPPONENT MODELING ERROR</b>\n{error_msg}")
         
         # Evaluate periodically
         if iteration % 20 == 0 or iteration == num_iterations:
@@ -517,13 +528,14 @@ def train_mixed_with_opponent_modeling(
             
             # Check for suspicious zero profit
             if abs(avg_profit_models) < 0.01:
-                notifier.send_message(
-                    f"⚠️ <b>ZERO PROFIT ALERT</b> at iteration {iteration}\n"
-                    f"This suggests games may not be completing properly."
-                )
+                if notifier:
+                    notifier.send_message(
+                        f"⚠️ <b>ZERO PROFIT ALERT</b> at iteration {iteration}\n"
+                        f"This suggests games may not be completing properly."
+                    )
             
             # Send progress update every 100 iterations or if a significant change occurs
-            if iteration % 100 == 0:
+            if notifier and iteration % 100 == 0:
                 notifier.send_training_progress(iteration, avg_profit_models, avg_profit_random)
         
         # Save checkpoint
@@ -534,7 +546,8 @@ def train_mixed_with_opponent_modeling(
             
             # Notify on checkpoint save
             if iteration % 500 == 0:  # Less frequent notifications for checkpoints
-                notifier.send_message(f"💾 <b>CHECKPOINT SAVED</b> at iteration {iteration}")
+                if notifier:
+                    notifier.send_message(f"💾 <b>CHECKPOINT SAVED</b> at iteration {iteration}")
         
         # Log memory sizes
         writer.add_scalar('Memory/Advantage', len(agent.advantage_memory), iteration)
@@ -583,12 +596,13 @@ def train_mixed_with_opponent_modeling(
     writer.add_scalar('Performance/FinalProfitVsModels', avg_profit_models, 0)
     
     # Final notification
-    notifier.send_message(
-        f"✅ <b>TRAINING COMPLETED</b>\n"
-        f"Total iterations: {num_iterations}\n"
-        f"Final profit vs random: {avg_profit_random:.2f}\n"
-        f"Final profit vs models: {avg_profit_models:.2f}"
-    )
+    if notifier:
+        notifier.send_message(
+            f"✅ <b>TRAINING COMPLETED</b>\n"
+            f"Total iterations: {num_iterations}\n"
+            f"Final profit vs random: {avg_profit_random:.2f}\n"
+            f"Final profit vs models: {avg_profit_models:.2f}"
+        )
     
     # Close the tensorboard writer
     writer.close()

--- a/src/training/train_with_opponent_modeling.py
+++ b/src/training/train_with_opponent_modeling.py
@@ -6,8 +6,6 @@ import os
 import random
 import time
 import argparse
-from torch.utils.tensorboard import SummaryWriter
-from scripts.telegram_notifier import TelegramNotifier
 from src.opponent_modeling.deep_cfr_with_opponent_modeling import DeepCFRAgentWithOpponentModeling
 from src.core.model import set_verbose
 from src.agents.random_agent import RandomAgent
@@ -39,7 +37,7 @@ def evaluate_against_random(agent, num_games=500, num_players=6, iteration=0, no
                     
                     if current_player == agent.player_id:
                         # Use opponent modeling for the current opponent
-                        action = agent.choose_action(state, opponent_id=current_player)
+                        action = agent.choose_action(state, opponent_id=None)
                     else:
                         action = random_agents[current_player].choose_action(state)
                         
@@ -107,6 +105,9 @@ def train_deep_cfr_with_opponent_modeling(
     verbose=False
 ):
     """Train a Deep CFR agent with opponent modeling."""
+    from torch.utils.tensorboard import SummaryWriter
+    from scripts.telegram_notifier import TelegramNotifier
+
     # Set verbosity
     set_verbose(verbose)
     

--- a/tests/test_training_regressions.py
+++ b/tests/test_training_regressions.py
@@ -1,0 +1,145 @@
+import random
+import sys
+import types
+
+import numpy as np
+import torch
+
+class DummyWriter:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def add_scalar(self, *args, **kwargs):
+        pass
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+tensorboard_stub = types.ModuleType("torch.utils.tensorboard")
+tensorboard_stub.SummaryWriter = DummyWriter
+sys.modules.setdefault("tensorboard", types.ModuleType("tensorboard"))
+sys.modules["torch.utils.tensorboard"] = tensorboard_stub
+
+import src.training.train as train_mod
+from src.core.deep_cfr import DeepCFRAgent
+from src.opponent_modeling.deep_cfr_with_opponent_modeling import (
+    DeepCFRAgentWithOpponentModeling,
+)
+
+
+def write_checkpoint(path):
+    agent = DeepCFRAgent(player_id=0, num_players=6, device="cpu")
+    agent.iteration_count = 1
+    torch.save(
+        {
+            "iteration": agent.iteration_count,
+            "advantage_net": agent.advantage_net.state_dict(),
+            "strategy_net": agent.strategy_net.state_dict(),
+            "min_bet_size": agent.min_bet_size,
+            "max_bet_size": agent.max_bet_size,
+        },
+        path,
+    )
+
+
+def patch_training_side_effects(monkeypatch):
+    tensorboard_stub = types.ModuleType("torch.utils.tensorboard")
+    tensorboard_stub.SummaryWriter = DummyWriter
+    monkeypatch.setitem(sys.modules, "torch.utils.tensorboard", tensorboard_stub)
+    monkeypatch.setattr(train_mod, "evaluate_against_random", lambda *args, **kwargs: 0.0)
+    monkeypatch.setattr(
+        train_mod,
+        "evaluate_against_checkpoint_agents",
+        lambda *args, **kwargs: 0.0,
+    )
+
+
+def assert_replay_memory_shapes(agent):
+    assert len(agent.advantage_memory) > 0
+    assert len(agent.strategy_memory) > 0
+
+    state, opponent_features, action_type, bet_size, regret = agent.advantage_memory.buffer[0]
+    assert len(state) > 0
+    assert opponent_features.shape == (20,)
+    assert action_type in (0, 1, 2)
+    assert isinstance(float(bet_size), float)
+    assert isinstance(float(regret), float)
+
+    state, opponent_features, strategy, bet_size, iteration = agent.strategy_memory[0]
+    assert len(state) > 0
+    assert opponent_features.shape == (20,)
+    assert strategy.shape == (agent.num_actions,)
+    assert np.isclose(strategy.sum(), 1.0)
+    assert isinstance(float(bet_size), float)
+    assert iteration == 1
+
+
+def test_self_play_training_smoke(tmp_path, monkeypatch):
+    patch_training_side_effects(monkeypatch)
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
+
+    checkpoint_path = tmp_path / "checkpoint.pt"
+    write_checkpoint(checkpoint_path)
+
+    agent, losses, profits = train_mod.train_against_checkpoint(
+        checkpoint_path=str(checkpoint_path),
+        additional_iterations=1,
+        traversals_per_iteration=1,
+        save_dir=str(tmp_path / "models"),
+        log_dir=str(tmp_path / "logs"),
+        verbose=False,
+    )
+
+    assert losses == [0]
+    assert profits == [0.0, 0.0]
+    assert_replay_memory_shapes(agent)
+
+
+def test_mixed_training_smoke(tmp_path, monkeypatch):
+    patch_training_side_effects(monkeypatch)
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
+
+    checkpoint_dir = tmp_path / "pool"
+    checkpoint_dir.mkdir()
+    write_checkpoint(checkpoint_dir / "t_seed.pt")
+
+    agent, losses, profits, profits_vs_checkpoints = train_mod.train_with_mixed_checkpoints(
+        checkpoint_dir=str(checkpoint_dir),
+        training_model_prefix="t_",
+        additional_iterations=1,
+        traversals_per_iteration=1,
+        save_dir=str(tmp_path / "models"),
+        log_dir=str(tmp_path / "logs"),
+        refresh_interval=1000,
+        num_opponents=1,
+        verbose=False,
+    )
+
+    assert losses == [0]
+    assert profits == [0.0, 0.0]
+    assert profits_vs_checkpoints == [0.0, 0.0]
+    assert_replay_memory_shapes(agent)
+
+
+def test_save_model_respects_explicit_pt_path(tmp_path):
+    model_path = tmp_path / "model.pt"
+    agent = DeepCFRAgent(player_id=0, num_players=6, device="cpu")
+    agent.iteration_count = 7
+    agent.save_model(model_path)
+    assert model_path.exists()
+    assert not (tmp_path / "model.pt_iteration_7.pt").exists()
+
+    om_model_path = tmp_path / "om_model.pt"
+    om_agent = DeepCFRAgentWithOpponentModeling(player_id=0, num_players=6, device="cpu")
+    om_agent.iteration_count = 3
+    om_agent.save_model(om_model_path)
+    assert om_model_path.exists()
+    assert not (tmp_path / "om_model.pt_iteration_3.pt").exists()


### PR DESCRIPTION
## Summary

This PR fixes issue `#22` by repairing the broken Phase 2 self-play and Phase 3 mixed-training paths, then cleaning up related training inconsistencies across the repo so the project is in a runnable state again.

The immediate issue was not just poor performance. The self-play / mixed-training code paths in `src/training/train.py` had drifted away from the core CFR implementation and were broken at a mechanical level:
- calling methods that no longer exist
- writing the wrong tuple shape into replay memory
- skipping the current bet-size handling used by the main CFR path
- relying on monkeypatched traversal copies that had diverged from the maintained implementation

This PR brings those paths back into alignment with the core training code and adds regression coverage so they do not silently break again.

Closes #22

## Root Cause

`src/training/train.py` contained separate custom traversal implementations for:
- self-play training
- mixed checkpoint training

Those copies were stale relative to `src/core/deep_cfr.py::DeepCFRAgent.cfr_traverse`.

As a result, Phase 2 / 3 could fail with the exact kinds of errors reported in the issue:
- missing `get_legal_action_ids`
- wrong action conversion path
- incorrect replay-memory API usage
- wrong experience tuple shape for `train_advantage_network`

There were also several supporting inconsistencies around imports, save/load behavior, and optional integrations that made the training entrypoints more fragile than they needed to be.

## What Changed

### 1. Replaced stale self-play / mixed traversal copies with one shared helper

Updated [src/training/train.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/training/train.py):

- added `_cfr_traverse_with_opponents(...)`
- both self-play and mixed-checkpoint training now use that helper instead of monkeypatching `DeepCFRAgent.cfr_traverse`
- the helper mirrors the maintained core CFR traversal logic for:
  - legal action handling
  - bet-size prediction for raises
  - regret calculation
  - prioritized replay insertion
  - strategy replay insertion

This specifically fixes the replay-memory mismatches that were causing the reported Phase 2 errors.

### 2. Added regression coverage for training entrypoints

Added [tests/test_training_regressions.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/tests/test_training_regressions.py):

- `test_self_play_training_smoke`
- `test_mixed_training_smoke`
- `test_save_model_respects_explicit_pt_path`

These tests run minimal self-play and mixed-training smoke paths and verify that:
- training entrypoints execute without the reported traversal/runtime failures
- replay memories contain the expected 5-field records
- explicit `.pt` save paths are handled correctly

This is intended as a future guardrail for exactly the kind of drift that caused issue `#22`.

### 3. Standardized model save/load behavior

Updated:
- [src/core/deep_cfr.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/core/deep_cfr.py)
- [src/opponent_modeling/deep_cfr_with_opponent_modeling.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/opponent_modeling/deep_cfr_with_opponent_modeling.py)

Changes:
- `save_model()` now accepts either:
  - a path prefix
  - or an explicit `.pt` filename
- `load_model()` now uses `map_location=self.device`

This removes filename inconsistencies across training scripts and makes checkpoint loading safer across CPU/GPU environments.

### 4. Removed duplicated action-conversion drift in opponent-modeling agent

Updated [src/opponent_modeling/deep_cfr_with_opponent_modeling.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/opponent_modeling/deep_cfr_with_opponent_modeling.py):

- reused `DeepCFRAgent.action_type_to_pokers_action`
- reused `DeepCFRAgent.get_legal_action_types`

This ensures raise legality / fallback behavior stays aligned between the standard agent and the opponent-modeling agent.

### 5. Reduced import-time fragility

Updated:
- [src/__init__.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/__init__.py)
- [src/training/__init__.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/training/__init__.py)
- [scripts/__init__.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/scripts/__init__.py)

These package initializers no longer eagerly import unrelated modules on package import.

This matters because importing one training module previously dragged in optional dependencies like:
- `tensorboard`
- `matplotlib`
- Telegram-related script code

That made tests and tooling fail during import before the actual target code even ran.

### 6. Cleaned up training entrypoints around optional integrations and opponent handling

Updated:
- [src/training/train_with_opponent_modeling.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/training/train_with_opponent_modeling.py)
- [src/training/train_mixed_with_opponent_modeling.py](/Users/dberweger/Local/deepcfr-texas-no-limit-holdem-6-players/src/training/train_mixed_with_opponent_modeling.py)

Changes include:
- deferring `SummaryWriter` / `TelegramNotifier` imports into runtime paths where needed
- making Telegram initialization non-fatal in mixed opponent-model training
- fixing fallback opponent list shape in mixed opponent-model training when no checkpoints are found
- removing a few inconsistent / stale code paths that made maintenance harder

## Why This Approach

The core issue was code drift.

Instead of applying another one-off patch only to the exact failing line numbers from the issue report, this PR:
- removes the stale duplicated traversal logic
- reuses the maintained CFR behavior
- adds regression tests at the training-entrypoint level

That is the smallest approach that actually reduces the chance of the same class of bug returning.

## Validation

Ran locally:

```bash
python3 -m pytest tests/test_training_regressions.py -q
python3 -m pytest tests/test_pokers_regressions.py -q
python3 -m compileall src scripts tests
Results:

tests/test_training_regressions.py: passed
tests/test_pokers_regressions.py: passed
compileall: passed
Notes
This PR fixes the broken training path behind issue #22.

It does not claim to fully resolve the separate empirical question of whether training profit matches the article’s reported numbers. That part may still depend on:

training setup
seeds / variance
hyperparameters
later algorithmic tuning
What this PR does establish is that Phase 2 / 3 no longer fail because of stale traversal and replay-memory bugs.