### PR TITLE
Loosen dependency pins for newer Python installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.5.1
+torch>=2.5.1,<3.0
 numpy==1.26.4
 matplotlib==3.9.0
 tensorboard==2.18.0
@@ -8,5 +8,5 @@ pokers @ git+https://github.com/dberweger2017/pokers.git@b1a48bd2067176cb73f9528
 python-dotenv==1.0.1
 requests==2.32.3
 seaborn==0.13.2
-pandas==2.2.2
+pandas>=2.2.2,<3.0
 PyQt5==5.15.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 torch>=2.5.1,<3.0
-numpy==1.26.4
-matplotlib==3.9.0
+numpy==1.26.4; python_version < "3.13"
+numpy>=2.1,<3.0; python_version >= "3.13"
+matplotlib==3.9.0; python_version < "3.13"
+matplotlib>=3.10.7,<3.11; python_version >= "3.13"
 tensorboard==2.18.0
 argparse
 tqdm==4.67.0
@@ -8,5 +10,5 @@ pokers @ git+https://github.com/dberweger2017/pokers.git@b1a48bd2067176cb73f9528
 python-dotenv==1.0.1
 requests==2.32.3
 seaborn==0.13.2
-pandas>=2.2.2,<3.0
+pandas>=2.3.3,<3.0
 PyQt5==5.15.11


### PR DESCRIPTION
Closes #35.

This relaxes the torch and pandas pins so pip can pick wheels that match newer Python and ROCm setups.

I also kept the existing NumPy and matplotlib pins for older Python, but let Python 3.13+ resolve to versions with current wheels. The old pins made Python 3.14 fall back to source builds before the install could finish.

Checked:
- `python3.10 -m pip install --dry-run -r requirements.txt`
- `python3.11 -m pip install --dry-run -r requirements.txt`
- Python 3.14 temporary venv: `pip install --dry-run -r requirements.txt`
